### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,19 +5,19 @@ PyAirview
 .. _CC2011: http://www.ti.com/product/cc2511
 .. _DEVICE_API.md: https://github.com/infincia/pyairview/blob/master/DEVICE_API.md
 
-.. image:: https://pypip.in/license/pyairview/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/pyairview.svg?style=flat
     :target: https://pypi.python.org/pypi/pyairview/
     :alt: License
 
-.. image:: https://pypip.in/py_versions/pyairview/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/pyairview.svg?style=flat
     :target: https://pypi.python.org/pypi/pyairview/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/status/pyairview/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/status/pyairview.svg?style=flat
     :target: https://pypi.python.org/pypi/pyairview/
     :alt: Development Status
     
-.. image:: https://pypip.in/version/pyairview/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/pyairview.svg?style=flat
     :target: https://pypi.python.org/pypi/pyairview/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyairview))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyairview`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.